### PR TITLE
Slightly refactor font settings.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -3302,9 +3302,26 @@ function setPostsPerColumn( posts ) {
     }
     trimPosts();
 }
-function setFontFamily( family ) {
+var availableFontFamilies = {
+    'Helvetica': 'Helvetica',
+    'Arial': 'Arial',
+    'Comic Sans MS': 'Comic Sans MS',
+    'Courier New': 'Courier New',
+    'Geneva': 'Geneva',
+    'Georgia': 'Georgia',
+    'Monospace': 'Monospace',
+    'Palatino Linotype': 'Palatino Linotype',
+    'Sans Serif': 'sans-serif',
+    'Serif': 'serif',
+    'Tahoma': 'Tahoma',
+    'Times New Roman': 'Times New Roman',
+    'Verdana': 'Verdana',
+    'Apple System Font': '-apple-system, Helvetica Neue, sans-serif'
+};
+function setFontFamily( familyName ) {
+    var family = availableFontFamilies[familyName];
     document.body.style.fontFamily = family;
-    saveStorage('font_family', family);
+    saveStorage('font_family', familyName);
 }
 function setFontSize( size_px ) {
     var options = [10, 12, 14, 16, 18, 20];

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -243,16 +243,15 @@ function fillPrefsWindow( opt ) {
                           '18': { 'label': "Bigger", 'icon': "fa-font" },
                           '20': { 'label': "HUGE!", 'icon': "fa-font" }
                         };
-            var families = ['Helvetica', 'Arial', 'Comic Sans MS', 'Courier New', 'Geneva', 'Georgia', 'Monospace',
-                            'Palatino Linotype', 'Sans Serif', 'Serif', 'Tahoma', 'Times New Roman', 'Verdana'];
+
             var size_px = readStorage('font_size');
             var ff = readStorage('font_family');
             html = '<strong class="lbltxt" style="width: 95%; padding: 0 2.5%;">Choose Your Text Preferences.</strong>' +
                    '<label class="lbltxt" for="preset">Font Family:</label>' +
                    '<select id="preset" onChange="setFontFamily(this.value);">';
-            for ( idx in families ) {
-                var selText = ( families[idx] === ff ) ? ' selected' : '';
-                html += '<option value="' + families[idx] + '" style="font-family: ' + families[idx] + ';"' + selText + '>' + families[idx] + '</option>';
+            for ( familyName in availableFontFamilies ) {
+                var selText = ( familyName === ff ) ? ' selected' : '';
+                html += '<option value="' + familyName + '" style="font-family: ' + availableFontFamilies[familyName] + ';"' + selText + '>' + familyName + '</option>';
             }
             html += '</select>';
             for ( item in items ) {


### PR DESCRIPTION
* The name of the font no longer is put directly in to the `font-family:` style attribute, so now fallbacks are possible.
* Also fixes #178 because `font-family: Sans Serif` is not valid. 
* Adds "Apple System Font" to use San Francisco in OS X 10.11.